### PR TITLE
Fix the issue where dataset_run cannot be scored

### DIFF
--- a/pkg/scores/score.go
+++ b/pkg/scores/score.go
@@ -98,9 +98,9 @@ func (r *CreateScoreRequest) validate() error {
 	if r.Value == nil {
 		return errors.New("'value' is required")
 	}
-	// At least one of TraceID, SessionID, or ObservationID must be provided
+	// At least one of TraceID, SessionID, or DatasetRunID must be provided
 	if r.TraceID == "" && r.SessionID == "" && r.DatasetRunID == "" {
-		return errors.New("at least one of 'traceId', 'sessionId', or 'observationId' is required")
+		return errors.New("at least one of 'traceId', 'sessionId', or 'datasetRunID' is required")
 	}
 	// Validate value according to data type
 	if err := r.validateValueByDataType(); err != nil {

--- a/pkg/scores/score.go
+++ b/pkg/scores/score.go
@@ -99,7 +99,7 @@ func (r *CreateScoreRequest) validate() error {
 		return errors.New("'value' is required")
 	}
 	// At least one of TraceID, SessionID, or ObservationID must be provided
-	if r.TraceID == "" && r.SessionID == "" && r.ObservationID == "" {
+	if r.TraceID == "" && r.SessionID == "" && r.DatasetRunID == "" {
 		return errors.New("at least one of 'traceId', 'sessionId', or 'observationId' is required")
 	}
 	// Validate value according to data type

--- a/pkg/scores/score_test.go
+++ b/pkg/scores/score_test.go
@@ -44,6 +44,7 @@ func TestCreateScoreRequest_validate(t *testing.T) {
 			request: CreateScoreRequest{
 				Name:          "relevance",
 				Value:         1.0,
+				TraceID:       "trace-123",
 				ObservationID: "obs-789",
 			},
 			wantErr: false,
@@ -73,7 +74,7 @@ func TestCreateScoreRequest_validate(t *testing.T) {
 				Value: 0.8,
 			},
 			wantErr: true,
-			errMsg:  "at least one of 'traceId', 'sessionId', or 'observationId' is required",
+			errMsg:  "at least one of 'traceId', 'sessionId', or 'datasetRunID' is required",
 		},
 	}
 


### PR DESCRIPTION
The source code is as follows:https://github.com/langfuse/langfuse/blob/6326a6d78874864abe0cb49957b69d3b7a7adfbd/packages/shared/src/utils/scores.ts#L13-L18
```ts
import z from "zod/v4";

export const applyScoreValidation = <T extends z.ZodType<any, any, any>>(
  schema: T,
) => {
  return schema.refine(
    (data) => {
      const hasTraceId = !!data.traceId;
      const hasSessionId = !!data.sessionId;
      const hasDatasetRunId = !!data.datasetRunId;

      return (
        (hasTraceId && !hasSessionId && !hasDatasetRunId) ||
        (hasSessionId &&
          !hasTraceId &&
          !hasDatasetRunId &&
          !data.observationId) ||
        (hasDatasetRunId && !hasTraceId && !hasSessionId && !data.observationId)
      );
    },
    {
      message:
        "Provide exactly one of the following: traceId (with optional observationId), sessionId or datasetRunId. ObservationId requires traceId.",
      path: ["traceId", "sessionId", "datasetRunId", "observationId"],
    },
  );
};
```
