### PR TITLE
 Fix unable to use `runDescription` in CreateDatasetRunItem API

### DIFF
--- a/pkg/datasets/run.go
+++ b/pkg/datasets/run.go
@@ -68,7 +68,8 @@ type DeleteDatasetRunResponse struct {
 type CreateDatasetRunItemRequest struct {
 	RunName string `json:"runName"`
 	// Description of the run. If run exists, description will be updated.
-	DatasetItemID string `json:"datasetItemId,omitempty"`
+	RunDescription string `json:"runDescription"`
+	DatasetItemID  string `json:"datasetItemId,omitempty"`
 	// Metadata of the dataset run, updates run if run already exists
 	Metadata      any    `json:"metadata,omitempty"`
 	ObservationID string `json:"observationId,omitempty"`


### PR DESCRIPTION
add runDescription filed

<img width="1050" height="429" alt="image" src="https://github.com/user-attachments/assets/d07a590f-b0e4-409d-b239-37f307f212c4" />
