### PR TITLE
Observation supports more fields, like promptName, promptVersion

### DIFF
--- a/pkg/traces/observation.go
+++ b/pkg/traces/observation.go
@@ -51,6 +51,8 @@ type Observation struct {
 	TraceID             string           `json:"traceId,omitempty"`
 	Type                ObservationType  `json:"type"`
 	Name                string           `json:"name,omitempty"`
+	PromptName          string           `json:"promptName,omitempty"`
+	PromptVersion       int              `json:"promptVersion,omitempty"`
 	StartTime           time.Time        `json:"startTime,omitempty"`
 	EndTime             time.Time        `json:"endTime,omitempty"`
 	CompletionStartTime time.Time        `json:"completionStartTime,omitempty"`

--- a/pkg/traces/observation_test.go
+++ b/pkg/traces/observation_test.go
@@ -36,6 +36,8 @@ func TestObservation_Fields(t *testing.T) {
 		Name:                "test-generation",
 		Model:               "gpt-4",
 		ModelParameters:     map[string]any{"temperature": 0.7},
+		PromptName:          "test-prompt",
+		PromptVersion:       1,
 		Input:               "test input",
 		Version:             "1.0",
 		Metadata:            map[string]any{"key": "value"},
@@ -53,6 +55,8 @@ func TestObservation_Fields(t *testing.T) {
 	assert.Equal(t, "test-generation", observation.Name)
 	assert.Equal(t, "gpt-4", observation.Model)
 	assert.Equal(t, map[string]any{"temperature": 0.7}, observation.ModelParameters)
+	assert.Equal(t, "test-prompt", observation.PromptName)
+	assert.Equal(t, 1, observation.PromptVersion)
 	assert.Equal(t, "test input", observation.Input)
 	assert.Equal(t, "1.0", observation.Version)
 	assert.Equal(t, map[string]any{"key": "value"}, observation.Metadata)


### PR DESCRIPTION
According to the documentation of [Metrics API](https://langfuse.com/docs/metrics/features/metrics-api#observation-dimensions)
- add fields PromptName and PromptVersion to Observation.

The effect of these fields is shown in the following image:
<img width="1494" height="245" alt="image" src="https://github.com/user-attachments/assets/5aeae219-e0b1-42c1-8c5c-6018d5417d41" />
