### PR TITLE
Update existing API contracts

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -937,9 +937,10 @@ func runProjectTests(client *langfuse.Langfuse) {
 
 	// Test updating a project (demonstration only)
 	fmt.Println("Demonstrating project update request structure...")
+	updateRetention := 60
 	testUpdate := &projects.UpdateProjectRequest{
 		Name:      "updated-test-project",
-		Retention: 60,
+		Retention: &updateRetention,
 		Metadata: map[string]interface{}{
 			"environment": "production",
 			"purpose":     "updated-purpose",
@@ -948,7 +949,7 @@ func runProjectTests(client *langfuse.Langfuse) {
 	}
 
 	fmt.Printf("Sample project update: Name=%s, Retention=%d days\n",
-		testUpdate.Name, testUpdate.Retention)
+		testUpdate.Name, *testUpdate.Retention)
 	fmt.Printf("Updated metadata: %v\n", testUpdate.Metadata)
 
 	fmt.Println("Skipping actual project update to prevent unintended changes")

--- a/pkg/annotations/item.go
+++ b/pkg/annotations/item.go
@@ -26,13 +26,14 @@ const (
 
 // QueueObjectType represents the type of object that can be queued for annotation.
 //
-// Currently supports traces and observations as the object types
+// Supports traces, observations, and sessions as the object types
 // that can be added to annotation queues.
 type QueueObjectType string
 
 const (
 	ObjectTypeTrace       QueueObjectType = "TRACE"
 	ObjectTypeObservation QueueObjectType = "OBSERVATION"
+	ObjectTypeSession     QueueObjectType = "SESSION"
 )
 
 // Item represents an annotation queue item.
@@ -61,8 +62,8 @@ func (r *CreateItemRequest) validate() error {
 	if r.ObjectType == "" {
 		return errors.New("'objectType' is required")
 	}
-	if r.ObjectType != ObjectTypeTrace && r.ObjectType != ObjectTypeObservation {
-		return fmt.Errorf("invalid 'objectType': %s, must be one of [TRACE, OBSERVATION]", r.ObjectType)
+	if r.ObjectType != ObjectTypeTrace && r.ObjectType != ObjectTypeObservation && r.ObjectType != ObjectTypeSession {
+		return fmt.Errorf("invalid 'objectType': %s, must be one of [TRACE, OBSERVATION, SESSION]", r.ObjectType)
 	}
 	if r.Status != "" && r.Status != StatusPending && r.Status != StatusCompleted {
 		return fmt.Errorf("invalid 'status': %s, must be one of [PENDING, COMPLETED]", r.Status)

--- a/pkg/annotations/item_test.go
+++ b/pkg/annotations/item_test.go
@@ -56,6 +56,15 @@ func TestCreateItemRequest_validate(t *testing.T) {
 			"",
 		},
 		{
+			"valid session request",
+			CreateItemRequest{
+				ObjectID:   "session-789",
+				ObjectType: ObjectTypeSession,
+			},
+			false,
+			"",
+		},
+		{
 			"missing objectId",
 			CreateItemRequest{
 				ObjectType: ObjectTypeTrace,

--- a/pkg/comments/comment.go
+++ b/pkg/comments/comment.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/git-hulk/langfuse-go/pkg/common"
 
@@ -57,6 +58,9 @@ func (c *CommentEntry) validate() error {
 	if c.Content == "" {
 		return errors.New("'content' is required")
 	}
+	if utf8.RuneCountInString(c.Content) > 5000 {
+		return errors.New("'content' must not exceed 5000 characters")
+	}
 	return nil
 }
 
@@ -84,6 +88,9 @@ func (c *CreateCommentRequest) validate() error {
 	}
 	if c.Content == "" {
 		return errors.New("'content' is required")
+	}
+	if utf8.RuneCountInString(c.Content) > 5000 {
+		return errors.New("'content' must not exceed 5000 characters")
 	}
 	return nil
 }

--- a/pkg/comments/comment_test.go
+++ b/pkg/comments/comment_test.go
@@ -2,6 +2,7 @@ package comments
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -95,6 +96,16 @@ func TestCreateCommentRequest_validate(t *testing.T) {
 				ProjectID:  "project-123",
 				ObjectType: ObjectTypeTrace,
 				ObjectID:   "trace-123",
+			},
+			wantErr: true,
+		},
+		{
+			name: "content exceeds current API limit",
+			request: CreateCommentRequest{
+				ProjectID:  "project-123",
+				ObjectType: ObjectTypeTrace,
+				ObjectID:   "trace-123",
+				Content:    strings.Repeat("a", 5001),
 			},
 			wantErr: true,
 		},

--- a/pkg/datasets/dataset.go
+++ b/pkg/datasets/dataset.go
@@ -26,13 +26,16 @@ import (
 // A dataset is a collection of data items used for training, evaluation, or testing
 // AI models. It includes identification, descriptive information, and audit timestamps.
 type Dataset struct {
-	ID          string    `json:"id"`
-	Name        string    `json:"name"`
-	Description string    `json:"description,omitempty"`
-	Metadata    any       `json:"metadata,omitempty"`
-	ProjectID   string    `json:"projectId"`
-	CreatedAt   time.Time `json:"createdAt"`
-	UpdatedAt   time.Time `json:"updatedAt"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Metadata    any    `json:"metadata,omitempty"`
+	InputSchema any    `json:"inputSchema,omitempty"`
+	// ExpectedOutputSchema is the JSON Schema used to validate expected outputs.
+	ExpectedOutputSchema any       `json:"expectedOutputSchema,omitempty"`
+	ProjectID            string    `json:"projectId"`
+	CreatedAt            time.Time `json:"createdAt"`
+	UpdatedAt            time.Time `json:"updatedAt"`
 }
 
 // CreateDatasetRequest represents the parameters for creating a new dataset.
@@ -43,6 +46,9 @@ type CreateDatasetRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	Metadata    any    `json:"metadata,omitempty"`
+	InputSchema any    `json:"inputSchema,omitempty"`
+	// ExpectedOutputSchema is the JSON Schema used to validate expected outputs.
+	ExpectedOutputSchema any `json:"expectedOutputSchema,omitempty"`
 }
 
 func (r *CreateDatasetRequest) validate() error {

--- a/pkg/datasets/dataset_test.go
+++ b/pkg/datasets/dataset_test.go
@@ -26,9 +26,11 @@ func TestCreateDatasetRequest_validate(t *testing.T) {
 		{
 			name: "valid request with all fields",
 			request: CreateDatasetRequest{
-				Name:        "test-dataset",
-				Description: "A test dataset",
-				Metadata:    map[string]any{"version": "1.0"},
+				Name:                 "test-dataset",
+				Description:          "A test dataset",
+				Metadata:             map[string]any{"version": "1.0"},
+				InputSchema:          map[string]any{"type": "object"},
+				ExpectedOutputSchema: map[string]any{"type": "string"},
 			},
 			wantErr: false,
 		},
@@ -116,13 +118,15 @@ func TestClient_Get(t *testing.T) {
 			require.Equal(t, "GET", r.Method)
 
 			dataset := Dataset{
-				ID:          "dataset-123",
-				Name:        datasetName,
-				Description: "Test dataset description",
-				Metadata:    map[string]any{"version": "1.0"},
-				ProjectID:   "project-456",
-				CreatedAt:   mustParseTime("2023-01-01T10:00:00Z"),
-				UpdatedAt:   mustParseTime("2023-01-02T11:00:00Z"),
+				ID:                   "dataset-123",
+				Name:                 datasetName,
+				Description:          "Test dataset description",
+				Metadata:             map[string]any{"version": "1.0"},
+				InputSchema:          map[string]any{"type": "object"},
+				ExpectedOutputSchema: map[string]any{"type": "string"},
+				ProjectID:            "project-456",
+				CreatedAt:            mustParseTime("2023-01-01T10:00:00Z"),
+				UpdatedAt:            mustParseTime("2023-01-02T11:00:00Z"),
 			}
 
 			w.Header().Set("Content-Type", "application/json")
@@ -141,6 +145,8 @@ func TestClient_Get(t *testing.T) {
 		require.Equal(t, datasetName, result.Name)
 		require.Equal(t, "Test dataset description", result.Description)
 		require.Equal(t, "project-456", result.ProjectID)
+		require.Equal(t, "object", result.InputSchema.(map[string]any)["type"])
+		require.Equal(t, "string", result.ExpectedOutputSchema.(map[string]any)["type"])
 	})
 
 	t.Run("get with empty dataset name", func(t *testing.T) {

--- a/pkg/datasets/item.go
+++ b/pkg/datasets/item.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/git-hulk/langfuse-go/pkg/common"
 )
@@ -17,17 +19,44 @@ import (
 // along with metadata and optional links to source traces or observations.
 // Items can have various statuses and are timestamped for audit purposes.
 type DatasetItem struct {
-	ID                  string    `json:"id,omitempty"`
-	DatasetID           string    `json:"datasetId,omitempty"`
-	DatasetName         string    `json:"datasetName,omitempty"`
-	Input               any       `json:"input,omitempty"`
-	ExpectedOutput      any       `json:"expectedOutput,omitempty"`
-	Metadata            any       `json:"metadata,omitempty"`
-	SourceTraceID       string    `json:"sourceTraceId,omitempty"`
-	SourceObservationID string    `json:"sourceObservationId,omitempty"`
-	Status              string    `json:"status,omitempty"`
-	CreatedAt           time.Time `json:"createdAt,omitempty"`
-	UpdatedAt           time.Time `json:"updatedAt,omitempty"`
+	ID                  string                      `json:"id,omitempty"`
+	DatasetID           string                      `json:"datasetId,omitempty"`
+	DatasetName         string                      `json:"datasetName,omitempty"`
+	Input               any                         `json:"input,omitempty"`
+	ExpectedOutput      any                         `json:"expectedOutput,omitempty"`
+	Metadata            any                         `json:"metadata,omitempty"`
+	SourceTraceID       string                      `json:"sourceTraceId,omitempty"`
+	SourceObservationID string                      `json:"sourceObservationId,omitempty"`
+	Status              string                      `json:"status,omitempty"`
+	CreatedAt           time.Time                   `json:"createdAt,omitempty"`
+	UpdatedAt           time.Time                   `json:"updatedAt,omitempty"`
+	MediaReferences     []DatasetItemMediaReference `json:"mediaReferences,omitempty"`
+}
+
+// DatasetItemMediaReferenceField identifies the dataset item field containing a media reference.
+type DatasetItemMediaReferenceField string
+
+const (
+	DatasetItemMediaReferenceFieldInput          DatasetItemMediaReferenceField = "input"
+	DatasetItemMediaReferenceFieldExpectedOutput DatasetItemMediaReferenceField = "expectedOutput"
+	DatasetItemMediaReferenceFieldMetadata       DatasetItemMediaReferenceField = "metadata"
+)
+
+// DatasetItemMediaReference describes a resolved Langfuse media reference in a dataset item.
+type DatasetItemMediaReference struct {
+	Field           DatasetItemMediaReferenceField `json:"field"`
+	ReferenceString string                         `json:"referenceString"`
+	JSONPath        string                         `json:"jsonPath"`
+	Media           DatasetItemMedia               `json:"media"`
+}
+
+// DatasetItemMedia contains metadata and a signed download URL for resolved media.
+type DatasetItemMedia struct {
+	MediaID       string `json:"mediaId"`
+	ContentType   string `json:"contentType"`
+	ContentLength int64  `json:"contentLength"`
+	URL           string `json:"url"`
+	URLExpiry     string `json:"urlExpiry"`
 }
 
 // CreateDatasetItemRequest represents the parameters for creating a new dataset item.
@@ -49,6 +78,9 @@ type CreateDatasetItemRequest struct {
 func (c *CreateDatasetItemRequest) validate() error {
 	if c.DatasetName == "" {
 		return errors.New("'datasetName' is required")
+	}
+	if utf8.RuneCountInString(c.ID) > 255 {
+		return errors.New("'id' must not exceed 255 characters")
 	}
 	return nil
 }
@@ -75,6 +107,7 @@ type ListDatasetItemParams struct {
 	DatasetName         string
 	SourceTraceID       string
 	SourceObservationID string
+	Version             time.Time
 	Page                int
 	Limit               int
 }
@@ -90,6 +123,9 @@ func (query *ListDatasetItemParams) ToQueryString() string {
 	}
 	if query.SourceObservationID != "" {
 		parts = append(parts, "sourceObservationId="+query.SourceObservationID)
+	}
+	if !query.Version.IsZero() {
+		parts = append(parts, "version="+url.QueryEscape(query.Version.Format(time.RFC3339)))
 	}
 	if query.Page != 0 {
 		parts = append(parts, "page="+strconv.Itoa(query.Page))

--- a/pkg/datasets/item_test.go
+++ b/pkg/datasets/item_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/stretchr/testify/require"
@@ -52,6 +54,14 @@ func TestCreateDatasetItemRequest_validate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "item ID exceeds current API limit",
+			request: CreateDatasetItemRequest{
+				DatasetName: "test-dataset",
+				ID:          strings.Repeat("a", 256),
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -83,8 +93,9 @@ func TestListDatasetItemParams_ToQueryString(t *testing.T) {
 				Page:        1,
 				Limit:       10,
 				DatasetName: "test-dataset",
+				Version:     time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC),
 			},
-			want: "datasetName=test-dataset&page=1&limit=10",
+			want: "datasetName=test-dataset&version=2026-07-29T10%3A00%3A00Z&page=1&limit=10",
 		},
 		{
 			name: "partial params",
@@ -149,10 +160,25 @@ func TestDatasetItemStructures(t *testing.T) {
 			Input:          map[string]any{"text": "hello"},
 			ExpectedOutput: map[string]any{"response": "hi"},
 			Metadata:       map[string]any{"model": "gpt-4"},
+			MediaReferences: []DatasetItemMediaReference{
+				{
+					Field:           DatasetItemMediaReferenceFieldInput,
+					ReferenceString: "@@@langfuseMedia:type=image/png|id=media-1|source=bytes@@@",
+					JSONPath:        "$['image']",
+					Media: DatasetItemMedia{
+						MediaID:       "media-1",
+						ContentType:   "image/png",
+						ContentLength: 42,
+						URL:           "https://example.com/media-1",
+						URLExpiry:     "2026-07-29T14:00:00Z",
+					},
+				},
+			},
 		}
 
 		require.Equal(t, "item-123", item.ID)
 		require.Equal(t, "test-dataset", item.DatasetName)
+		require.Equal(t, "media-1", item.MediaReferences[0].Media.MediaID)
 	})
 
 	t.Run("CreateDatasetItemRequest with optional fields", func(t *testing.T) {
@@ -186,6 +212,7 @@ func TestDatasetItemClient_List(t *testing.T) {
 			require.Equal(t, "10", query.Get("limit"))
 			require.Equal(t, "trace-123", query.Get("sourceTraceId"))
 			require.Equal(t, "obs-456", query.Get("sourceObservationId"))
+			require.Equal(t, "2026-07-29T10:00:00Z", query.Get("version"))
 
 			mockResponse := ListDatasetItems{
 				Metadata: common.ListMetadata{
@@ -229,6 +256,7 @@ func TestDatasetItemClient_List(t *testing.T) {
 			Limit:               10,
 			SourceTraceID:       "trace-123",
 			SourceObservationID: "obs-456",
+			Version:             time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC),
 		}
 
 		result, err := datasetClient.ListDatasetItems(ctx, params)

--- a/pkg/datasets/run.go
+++ b/pkg/datasets/run.go
@@ -74,7 +74,9 @@ type CreateDatasetRunItemRequest struct {
 	Metadata      any    `json:"metadata,omitempty"`
 	ObservationID string `json:"observationId,omitempty"`
 	// traceId should always be provided. For compatibility with older SDK versions it can also be inferred from the provided observationId.
-	TraceID string `json:"traceId"`
+	TraceID        string     `json:"traceId"`
+	DatasetVersion *time.Time `json:"datasetVersion,omitempty"`
+	CreatedAt      *time.Time `json:"createdAt,omitempty"`
 }
 
 func (r *CreateDatasetRunItemRequest) validate() error {

--- a/pkg/datasets/run_test.go
+++ b/pkg/datasets/run_test.go
@@ -210,6 +210,8 @@ func TestClient_CreateDatasetRunItems(t *testing.T) {
 		datasetItemId := "dataset-item-1"
 		traceId := "trace-1"
 		observationId := "observation-1"
+		datasetVersion := mustParseTime("2026-07-28T10:00:00Z")
+		createdAt := mustParseTime("2026-07-29T10:00:00Z")
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			require.Equal(t, "/dataset-run-items", r.URL.Path)
@@ -222,6 +224,8 @@ func TestClient_CreateDatasetRunItems(t *testing.T) {
 			require.Equal(t, datasetItemId, req.DatasetItemID)
 			require.Equal(t, traceId, req.TraceID)
 			require.Equal(t, observationId, req.ObservationID)
+			require.Equal(t, datasetVersion, *req.DatasetVersion)
+			require.Equal(t, createdAt, *req.CreatedAt)
 
 			runItem := DatasetRunItem{
 				ID:             "run-item-1",
@@ -244,10 +248,12 @@ func TestClient_CreateDatasetRunItems(t *testing.T) {
 		datasetClient := NewClient(client)
 
 		req := CreateDatasetRunItemRequest{
-			RunName:       runName,
-			DatasetItemID: datasetItemId,
-			TraceID:       traceId,
-			ObservationID: observationId,
+			RunName:        runName,
+			DatasetItemID:  datasetItemId,
+			TraceID:        traceId,
+			ObservationID:  observationId,
+			DatasetVersion: &datasetVersion,
+			CreatedAt:      &createdAt,
 		}
 		result, err := datasetClient.CreateDatasetRunItems(ctx, req)
 		require.NoError(t, err)

--- a/pkg/llmconnections/llmconnection.go
+++ b/pkg/llmconnections/llmconnection.go
@@ -41,16 +41,17 @@ const (
 // base URLs, and metadata. Sensitive information like API keys is excluded
 // from this structure for security reasons.
 type LLMConnection struct {
-	ID                string     `json:"id"`
-	Provider          string     `json:"provider"`
-	Adapter           LLMAdapter `json:"adapter"`
-	DisplaySecretKey  string     `json:"displaySecretKey"`
-	BaseURL           string     `json:"baseURL,omitempty"`
-	CustomModels      []string   `json:"customModels"`
-	WithDefaultModels bool       `json:"withDefaultModels"`
-	ExtraHeaderKeys   []string   `json:"extraHeaderKeys"`
-	CreatedAt         time.Time  `json:"createdAt"`
-	UpdatedAt         time.Time  `json:"updatedAt"`
+	ID                string         `json:"id"`
+	Provider          string         `json:"provider"`
+	Adapter           LLMAdapter     `json:"adapter"`
+	DisplaySecretKey  string         `json:"displaySecretKey"`
+	BaseURL           string         `json:"baseURL,omitempty"`
+	CustomModels      []string       `json:"customModels"`
+	WithDefaultModels bool           `json:"withDefaultModels"`
+	ExtraHeaderKeys   []string       `json:"extraHeaderKeys"`
+	Config            map[string]any `json:"config,omitempty"`
+	CreatedAt         time.Time      `json:"createdAt"`
+	UpdatedAt         time.Time      `json:"updatedAt"`
 }
 
 // UpsertLLMConnectionRequest represents the parameters for creating or updating an LLM connection.
@@ -66,6 +67,7 @@ type UpsertLLMConnectionRequest struct {
 	CustomModels      []string          `json:"customModels,omitempty"`
 	WithDefaultModels bool              `json:"withDefaultModels,omitempty"`
 	ExtraHeaders      map[string]string `json:"extraHeaders,omitempty"`
+	Config            map[string]any    `json:"config,omitempty"`
 }
 
 func (r *UpsertLLMConnectionRequest) validate() error {

--- a/pkg/llmconnections/llmconnection_test.go
+++ b/pkg/llmconnections/llmconnection_test.go
@@ -136,6 +136,7 @@ func TestClient_List(t *testing.T) {
 					"customModels": ["gpt-4"],
 					"withDefaultModels": true,
 					"extraHeaderKeys": ["X-Custom-Header"],
+					"config": {"useResponsesApi": true},
 					"createdAt": "2023-01-01T00:00:00Z",
 					"updatedAt": "2023-01-01T00:00:00Z"
 				}
@@ -168,6 +169,7 @@ func TestClient_List(t *testing.T) {
 	assert.Equal(t, []string{"gpt-4"}, result.Data[0].CustomModels)
 	assert.True(t, result.Data[0].WithDefaultModels)
 	assert.Equal(t, []string{"X-Custom-Header"}, result.Data[0].ExtraHeaderKeys)
+	assert.Equal(t, true, result.Data[0].Config["useResponsesApi"])
 }
 
 func TestClient_Upsert(t *testing.T) {
@@ -207,6 +209,7 @@ func TestClient_Upsert(t *testing.T) {
 		CustomModels:      []string{"gpt-4", "gpt-3.5-turbo"},
 		WithDefaultModels: withDefaultModels,
 		ExtraHeaders:      map[string]string{},
+		Config:            map[string]any{"useResponsesApi": true},
 	}
 
 	result, err := client.Upsert(context.Background(), req)

--- a/pkg/media/media.go
+++ b/pkg/media/media.go
@@ -24,41 +24,66 @@ import (
 type ContentType string
 
 const (
-	ContentTypeImagePNG               ContentType = "image/png"
-	ContentTypeImageJPEG              ContentType = "image/jpeg"
-	ContentTypeImageJPG               ContentType = "image/jpg"
-	ContentTypeImageWebP              ContentType = "image/webp"
-	ContentTypeImageGIF               ContentType = "image/gif"
-	ContentTypeImageSVGXML            ContentType = "image/svg+xml"
-	ContentTypeImageTIFF              ContentType = "image/tiff"
-	ContentTypeImageBMP               ContentType = "image/bmp"
-	ContentTypeAudioMPEG              ContentType = "audio/mpeg"
-	ContentTypeAudioMP3               ContentType = "audio/mp3"
-	ContentTypeAudioWAV               ContentType = "audio/wav"
-	ContentTypeAudioOGG               ContentType = "audio/ogg"
-	ContentTypeAudioOGA               ContentType = "audio/oga"
-	ContentTypeAudioAAC               ContentType = "audio/aac"
-	ContentTypeAudioMP4               ContentType = "audio/mp4"
-	ContentTypeAudioFLAC              ContentType = "audio/flac"
-	ContentTypeVideoMP4               ContentType = "video/mp4"
-	ContentTypeVideoWebM              ContentType = "video/webm"
-	ContentTypeTextPlain              ContentType = "text/plain"
-	ContentTypeTextHTML               ContentType = "text/html"
-	ContentTypeTextCSS                ContentType = "text/css"
-	ContentTypeTextCSV                ContentType = "text/csv"
-	ContentTypeApplicationPDF         ContentType = "application/pdf"
-	ContentTypeApplicationMSWord      ContentType = "application/msword"
-	ContentTypeApplicationMSExcel     ContentType = "application/vnd.ms-excel"
-	ContentTypeApplicationZIP         ContentType = "application/zip"
-	ContentTypeApplicationJSON        ContentType = "application/json"
-	ContentTypeApplicationXML         ContentType = "application/xml"
-	ContentTypeApplicationOctetStream ContentType = "application/octet-stream"
+	ContentTypeImagePNG                     ContentType = "image/png"
+	ContentTypeImageJPEG                    ContentType = "image/jpeg"
+	ContentTypeImageJPG                     ContentType = "image/jpg"
+	ContentTypeImageWebP                    ContentType = "image/webp"
+	ContentTypeImageGIF                     ContentType = "image/gif"
+	ContentTypeImageSVGXML                  ContentType = "image/svg+xml"
+	ContentTypeImageTIFF                    ContentType = "image/tiff"
+	ContentTypeImageBMP                     ContentType = "image/bmp"
+	ContentTypeImageAVIF                    ContentType = "image/avif"
+	ContentTypeImageHEIC                    ContentType = "image/heic"
+	ContentTypeAudioMPEG                    ContentType = "audio/mpeg"
+	ContentTypeAudioMP3                     ContentType = "audio/mp3"
+	ContentTypeAudioWAV                     ContentType = "audio/wav"
+	ContentTypeAudioOGG                     ContentType = "audio/ogg"
+	ContentTypeAudioOGA                     ContentType = "audio/oga"
+	ContentTypeAudioAAC                     ContentType = "audio/aac"
+	ContentTypeAudioMP4                     ContentType = "audio/mp4"
+	ContentTypeAudioFLAC                    ContentType = "audio/flac"
+	ContentTypeAudioOpus                    ContentType = "audio/opus"
+	ContentTypeAudioWebM                    ContentType = "audio/webm"
+	ContentTypeVideoMP4                     ContentType = "video/mp4"
+	ContentTypeVideoWebM                    ContentType = "video/webm"
+	ContentTypeVideoOGG                     ContentType = "video/ogg"
+	ContentTypeVideoMPEG                    ContentType = "video/mpeg"
+	ContentTypeVideoQuickTime               ContentType = "video/quicktime"
+	ContentTypeVideoAVI                     ContentType = "video/x-msvideo"
+	ContentTypeVideoMatroska                ContentType = "video/x-matroska"
+	ContentTypeTextPlain                    ContentType = "text/plain"
+	ContentTypeTextHTML                     ContentType = "text/html"
+	ContentTypeTextCSS                      ContentType = "text/css"
+	ContentTypeTextCSV                      ContentType = "text/csv"
+	ContentTypeTextMarkdown                 ContentType = "text/markdown"
+	ContentTypeTextPython                   ContentType = "text/x-python"
+	ContentTypeApplicationJavaScript        ContentType = "application/javascript"
+	ContentTypeTextTypeScript               ContentType = "text/x-typescript"
+	ContentTypeApplicationYAML              ContentType = "application/x-yaml"
+	ContentTypeApplicationPDF               ContentType = "application/pdf"
+	ContentTypeApplicationMSWord            ContentType = "application/msword"
+	ContentTypeApplicationMSExcel           ContentType = "application/vnd.ms-excel"
+	ContentTypeApplicationExcelOpenXML      ContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	ContentTypeApplicationZIP               ContentType = "application/zip"
+	ContentTypeApplicationJSON              ContentType = "application/json"
+	ContentTypeApplicationXML               ContentType = "application/xml"
+	ContentTypeApplicationOctetStream       ContentType = "application/octet-stream"
+	ContentTypeApplicationWordOpenXML       ContentType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	ContentTypeApplicationPowerPointOpenXML ContentType = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+	ContentTypeApplicationRTF               ContentType = "application/rtf"
+	ContentTypeApplicationNDJSON            ContentType = "application/x-ndjson"
+	ContentTypeApplicationParquet           ContentType = "application/vnd.apache.parquet"
+	ContentTypeApplicationGZIP              ContentType = "application/gzip"
+	ContentTypeApplicationTAR               ContentType = "application/x-tar"
+	ContentTypeApplication7Zip              ContentType = "application/x-7z-compressed"
 )
 
 // GetUploadURLRequest represents the request to get a presigned upload URL for media.
 type GetUploadURLRequest struct {
-	TraceID       string      `json:"traceId"`
+	TraceID       string      `json:"traceId,omitempty"`
 	ObservationID string      `json:"observationId,omitempty"`
+	DatasetID     string      `json:"datasetId,omitempty"`
+	DatasetItemID string      `json:"datasetItemId,omitempty"`
 	ContentType   ContentType `json:"contentType"`
 	ContentLength int         `json:"contentLength"`
 	SHA256Hash    string      `json:"sha256Hash"`
@@ -66,8 +91,8 @@ type GetUploadURLRequest struct {
 }
 
 func (r *GetUploadURLRequest) validate() error {
-	if r.TraceID == "" {
-		return errors.New("'traceId' is required")
+	if err := validateMediaContext(r.TraceID, r.ObservationID, r.DatasetID, r.DatasetItemID, r.Field); err != nil {
+		return err
 	}
 	if r.ContentType == "" {
 		return errors.New("'contentType' is required")
@@ -84,11 +109,30 @@ func (r *GetUploadURLRequest) validate() error {
 	if _, err := base64.StdEncoding.DecodeString(r.SHA256Hash); err != nil {
 		return errors.New("'sha256Hash' must be a valid base64 encoded string")
 	}
-	if r.Field == "" {
+	return nil
+}
+
+func validateMediaContext(traceID, observationID, datasetID, datasetItemID, field string) error {
+	hasTraceContext := traceID != "" || observationID != ""
+	hasDatasetContext := datasetID != "" || datasetItemID != ""
+	if hasTraceContext == hasDatasetContext {
+		return errors.New("exactly one media context is required: trace or dataset item")
+	}
+	if hasTraceContext && traceID == "" {
+		return errors.New("'traceId' is required for trace media")
+	}
+	if hasDatasetContext && (datasetID == "" || datasetItemID == "") {
+		return errors.New("'datasetId' and 'datasetItemId' are required for dataset item media")
+	}
+	if field == "" {
 		return errors.New("'field' is required")
 	}
-	if r.Field != "input" && r.Field != "output" && r.Field != "metadata" {
-		return fmt.Errorf("'field' must be one of: input, output, metadata")
+	if hasDatasetContext {
+		if field != "input" && field != "expectedOutput" && field != "metadata" {
+			return errors.New("'field' must be one of: input, expectedOutput, metadata for dataset item media")
+		}
+	} else if field != "input" && field != "output" && field != "metadata" {
+		return errors.New("'field' must be one of: input, output, metadata for trace media")
 	}
 	return nil
 }
@@ -214,25 +258,21 @@ func (c *Client) Patch(ctx context.Context, mediaID string, request *PatchMediaR
 
 // UploadFromBytesRequest represents the request for uploading media from bytes.
 type UploadFromBytesRequest struct {
-	TraceID       string      `json:"traceId"`
+	TraceID       string      `json:"traceId,omitempty"`
 	ObservationID string      `json:"observationId,omitempty"`
+	DatasetID     string      `json:"datasetId,omitempty"`
+	DatasetItemID string      `json:"datasetItemId,omitempty"`
 	ContentType   ContentType `json:"contentType"`
 	Field         string      `json:"field"`
 	Data          []byte      `json:"-"` // Not serialized to JSON
 }
 
 func (r *UploadFromBytesRequest) validate() error {
-	if r.TraceID == "" {
-		return errors.New("'traceId' is required")
+	if err := validateMediaContext(r.TraceID, r.ObservationID, r.DatasetID, r.DatasetItemID, r.Field); err != nil {
+		return err
 	}
 	if r.ContentType == "" {
 		return errors.New("'contentType' is required")
-	}
-	if r.Field == "" {
-		return errors.New("'field' is required")
-	}
-	if r.Field != "input" && r.Field != "output" && r.Field != "metadata" {
-		return fmt.Errorf("'field' must be one of: input, output, metadata")
 	}
 	if len(r.Data) == 0 {
 		return errors.New("'data' is required")
@@ -242,22 +282,18 @@ func (r *UploadFromBytesRequest) validate() error {
 
 // UploadFileRequest represents the request for uploading a media file.
 type UploadFileRequest struct {
-	TraceID       string      `json:"traceId"`
+	TraceID       string      `json:"traceId,omitempty"`
 	ObservationID string      `json:"observationId,omitempty"`
+	DatasetID     string      `json:"datasetId,omitempty"`
+	DatasetItemID string      `json:"datasetItemId,omitempty"`
 	ContentType   ContentType `json:"contentType"`
 	Field         string      `json:"field"`
 	FilePath      string      `json:"-"` // Not serialized to JSON
 }
 
 func (r *UploadFileRequest) validate() error {
-	if r.TraceID == "" {
-		return errors.New("'traceId' is required")
-	}
-	if r.Field == "" {
-		return errors.New("'field' is required")
-	}
-	if r.Field != "input" && r.Field != "output" && r.Field != "metadata" {
-		return fmt.Errorf("'field' must be one of: input, output, metadata")
+	if err := validateMediaContext(r.TraceID, r.ObservationID, r.DatasetID, r.DatasetItemID, r.Field); err != nil {
+		return err
 	}
 	if r.FilePath == "" {
 		return errors.New("'filePath' is required")
@@ -287,6 +323,8 @@ func (c *Client) UploadFromBytes(ctx context.Context, request *UploadFromBytesRe
 	uploadURLReq := &GetUploadURLRequest{
 		TraceID:       request.TraceID,
 		ObservationID: request.ObservationID,
+		DatasetID:     request.DatasetID,
+		DatasetItemID: request.DatasetItemID,
 		ContentType:   request.ContentType,
 		ContentLength: len(request.Data),
 		SHA256Hash:    sha256Hash,
@@ -382,6 +420,8 @@ func (c *Client) UploadFile(ctx context.Context, request *UploadFileRequest) (*U
 	return c.UploadFromBytes(ctx, &UploadFromBytesRequest{
 		TraceID:       request.TraceID,
 		ObservationID: request.ObservationID,
+		DatasetID:     request.DatasetID,
+		DatasetItemID: request.DatasetItemID,
 		ContentType:   contentType,
 		Field:         request.Field,
 		Data:          data,

--- a/pkg/media/media_test.go
+++ b/pkg/media/media_test.go
@@ -45,7 +45,20 @@ func TestGetMediaUploadURLRequest_validate(t *testing.T) {
 				Field:         "input",
 			},
 			true,
-			"'traceId' is required",
+			"exactly one media context is required",
+		},
+		{
+			"valid dataset item request",
+			GetUploadURLRequest{
+				DatasetID:     "dataset-123",
+				DatasetItemID: "item-123",
+				ContentType:   ContentTypeImagePNG,
+				ContentLength: 1024,
+				SHA256Hash:    "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+				Field:         "expectedOutput",
+			},
+			false,
+			"",
 		},
 		{
 			"missing content type",
@@ -232,7 +245,7 @@ func TestClient_GetUploadURL_ValidationError(t *testing.T) {
 
 	_, err := client.GetUploadURL(context.Background(), request)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "'traceId' is required")
+	require.Contains(t, err.Error(), "exactly one media context is required")
 }
 
 func TestClient_Get(t *testing.T) {
@@ -353,7 +366,19 @@ func TestUploadFromBytesRequest_validate(t *testing.T) {
 				Data:        []byte("test data"),
 			},
 			true,
-			"'traceId' is required",
+			"exactly one media context is required",
+		},
+		{
+			"valid dataset item request",
+			UploadFromBytesRequest{
+				DatasetID:     "dataset-123",
+				DatasetItemID: "item-123",
+				ContentType:   ContentTypeImagePNG,
+				Field:         "expectedOutput",
+				Data:          []byte("test data"),
+			},
+			false,
+			"",
 		},
 		{
 			"missing content type",
@@ -437,7 +462,19 @@ func TestUploadFileRequest_validate(t *testing.T) {
 				FilePath:    "/path/to/file.png",
 			},
 			true,
-			"'traceId' is required",
+			"exactly one media context is required",
+		},
+		{
+			"valid dataset item request",
+			UploadFileRequest{
+				DatasetID:     "dataset-123",
+				DatasetItemID: "item-123",
+				ContentType:   ContentTypeImagePNG,
+				Field:         "expectedOutput",
+				FilePath:      "/path/to/file.png",
+			},
+			false,
+			"",
 		},
 		{
 			"missing field",
@@ -564,7 +601,7 @@ func TestClient_UploadFromBytes_ValidationError(t *testing.T) {
 
 	_, err := client.UploadFromBytes(context.Background(), request)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "'traceId' is required")
+	require.Contains(t, err.Error(), "exactly one media context is required")
 }
 
 func TestClient_UploadFromBytes_ExistingFile(t *testing.T) {
@@ -671,7 +708,7 @@ func TestClient_UploadFile_ValidationError(t *testing.T) {
 
 	_, err := client.UploadFile(context.Background(), request)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "'traceId' is required")
+	require.Contains(t, err.Error(), "exactly one media context is required")
 }
 
 func TestClient_UploadFile_FileNotFound(t *testing.T) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,6 +24,7 @@ const (
 	ViewTraces            View = "traces"
 	ViewObservations      View = "observations"
 	ViewScoresNumeric     View = "scores-numeric"
+	ViewScoresBoolean     View = "scores-boolean"
 	ViewScoresCategorical View = "scores-categorical"
 )
 
@@ -66,6 +67,7 @@ var validViews = map[View]struct{}{
 	ViewTraces:            {},
 	ViewObservations:      {},
 	ViewScoresNumeric:     {},
+	ViewScoresBoolean:     {},
 	ViewScoresCategorical: {},
 }
 
@@ -105,6 +107,9 @@ var validMeasuresByView = map[View]map[string]struct{}{
 	ViewScoresNumeric: {
 		MeasureCount: {},
 		MeasureValue: {},
+	},
+	ViewScoresBoolean: {
+		MeasureCount: {},
 	},
 	ViewScoresCategorical: {
 		MeasureCount: {},

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -147,6 +147,15 @@ func TestQuery_ToQueryStringViewSpecificMeasures(t *testing.T) {
 		wantErr string
 	}{
 		{
+			name: "boolean scores support count",
+			query: &Query{
+				View:          ViewScoresBoolean,
+				Metrics:       []Metric{{Measure: MeasureCount, Aggregation: "count"}},
+				FromTimestamp: mustParseTime("2024-01-01T00:00:00Z"),
+				ToTimestamp:   mustParseTime("2024-01-02T00:00:00Z"),
+			},
+		},
+		{
 			name: "traces supports totalCost",
 			query: &Query{
 				View:          ViewTraces,

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -27,22 +27,63 @@ type TokenizerConfig struct {
 	TokensPerMessage int `json:"tokensPerMessage,omitempty"`
 }
 
+// ModelPrice is a price in USD for one usage unit.
+type ModelPrice struct {
+	Price float64 `json:"price"`
+}
+
+// PricingTierOperator is a comparison operator used by pricing tier conditions.
+type PricingTierOperator string
+
+const (
+	PricingTierOperatorGreaterThan        PricingTierOperator = "gt"
+	PricingTierOperatorGreaterThanOrEqual PricingTierOperator = "gte"
+	PricingTierOperatorLessThan           PricingTierOperator = "lt"
+	PricingTierOperatorLessThanOrEqual    PricingTierOperator = "lte"
+	PricingTierOperatorEqual              PricingTierOperator = "eq"
+	PricingTierOperatorNotEqual           PricingTierOperator = "neq"
+)
+
+// PricingTierCondition selects a pricing tier by comparing matching usage details.
+type PricingTierCondition struct {
+	UsageDetailPattern string              `json:"usageDetailPattern"`
+	Operator           PricingTierOperator `json:"operator"`
+	Value              float64             `json:"value"`
+	CaseSensitive      bool                `json:"caseSensitive"`
+}
+
+// PricingTier defines conditional prices for a model.
+//
+// ID is returned by Langfuse and is omitted when the tier is used in a create request.
+type PricingTier struct {
+	ID         string                 `json:"id,omitempty"`
+	Name       string                 `json:"name"`
+	IsDefault  bool                   `json:"isDefault"`
+	Priority   int                    `json:"priority"`
+	Conditions []PricingTierCondition `json:"conditions"`
+	Prices     map[string]float64     `json:"prices"`
+}
+
 // ModelEntry represents a model configuration with pricing and metadata.
 //
 // A model entry defines how a model is identified (via name and match pattern),
 // its pricing structure for input/output tokens, and tokenization configuration.
 // Models are used for cost tracking and analytics in Langfuse.
 type ModelEntry struct {
-	ID              string          `json:"id,omitempty"`
-	ModelName       string          `json:"modelName"`
-	MatchPattern    string          `json:"matchPattern,omitempty"`
-	StartDate       time.Time       `json:"startDate,omitempty"`
-	InputPrice      float64         `json:"inputPrice,omitempty"`
-	OutputPrice     float64         `json:"outputPrice,omitempty"`
-	TotalPrice      float64         `json:"totalPrice,omitempty"`
-	Unit            string          `json:"unit"`
-	TokenizerId     string          `json:"tokenizerId,omitempty"`
-	TokenizerConfig TokenizerConfig `json:"tokenizerConfig,omitempty"`
+	ID                string                `json:"id,omitempty"`
+	ModelName         string                `json:"modelName"`
+	MatchPattern      string                `json:"matchPattern,omitempty"`
+	StartDate         time.Time             `json:"startDate,omitempty"`
+	InputPrice        float64               `json:"inputPrice,omitempty"`
+	OutputPrice       float64               `json:"outputPrice,omitempty"`
+	TotalPrice        float64               `json:"totalPrice,omitempty"`
+	Unit              string                `json:"unit"`
+	TokenizerId       string                `json:"tokenizerId,omitempty"`
+	TokenizerConfig   TokenizerConfig       `json:"tokenizerConfig,omitempty"`
+	IsLangfuseManaged bool                  `json:"isLangfuseManaged,omitempty"`
+	CreatedAt         time.Time             `json:"createdAt,omitempty"`
+	Prices            map[string]ModelPrice `json:"prices,omitempty"`
+	PricingTiers      []PricingTier         `json:"pricingTiers,omitempty"`
 }
 
 func (m *ModelEntry) validate() error {

--- a/pkg/models/model_test.go
+++ b/pkg/models/model_test.go
@@ -6,10 +6,19 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/stretchr/testify/require"
 )
+
+func mustParseTime(value string) time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}
 
 func TestListParams_ToQueryString(t *testing.T) {
 	tests := []struct {
@@ -72,7 +81,22 @@ func TestModelClient_Get(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			require.Equal(t, "/models/test-model-id", r.URL.Path)
-			model := ModelEntry{ID: "test-model-id", ModelName: "gpt-4", Unit: "TOKENS"}
+			model := ModelEntry{
+				ID:        "test-model-id",
+				ModelName: "gpt-4",
+				Unit:      "TOKENS",
+				CreatedAt: mustParseTime("2026-07-29T10:00:00Z"),
+				PricingTiers: []PricingTier{
+					{
+						ID:         "tier-1",
+						Name:       "Standard",
+						IsDefault:  true,
+						Priority:   0,
+						Conditions: []PricingTierCondition{},
+						Prices:     map[string]float64{"input": 0.000003},
+					},
+				},
+			}
 			w.Header().Set("Content-Type", "application/json")
 			err := json.NewEncoder(w).Encode(model)
 			require.NoError(t, err)
@@ -86,6 +110,8 @@ func TestModelClient_Get(t *testing.T) {
 	require.Equal(t, "test-model-id", model.ID)
 	require.Equal(t, "gpt-4", model.ModelName)
 	require.Equal(t, "TOKENS", model.Unit)
+	require.Equal(t, "tier-1", model.PricingTiers[0].ID)
+	require.Equal(t, 0.000003, model.PricingTiers[0].Prices["input"])
 }
 
 func TestModelClient_Get_MissingID(t *testing.T) {
@@ -131,6 +157,9 @@ func TestModelClient_Create(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, "gpt-4-custom", model.ModelName)
 			require.Equal(t, "TOKENS", model.Unit)
+			require.Len(t, model.PricingTiers, 1)
+			require.True(t, model.PricingTiers[0].IsDefault)
+			require.Equal(t, 0.000003, model.PricingTiers[0].Prices["input"])
 			// Return the created model with an ID
 			model.ID = "created-model-id"
 			w.Header().Set("Content-Type", "application/json")
@@ -146,8 +175,15 @@ func TestModelClient_Create(t *testing.T) {
 		MatchPattern: ".*gpt-4.*",
 		ModelName:    "gpt-4-custom",
 		Unit:         "TOKENS",
-		InputPrice:   0.03,
-		OutputPrice:  0.06,
+		PricingTiers: []PricingTier{
+			{
+				Name:       "Standard",
+				IsDefault:  true,
+				Priority:   0,
+				Conditions: []PricingTierCondition{},
+				Prices:     map[string]float64{"input": 0.000003, "output": 0.000015},
+			},
+		},
 	}
 	model, err := client.Create(context.Background(), createModel)
 	require.NoError(t, err)

--- a/pkg/projects/project.go
+++ b/pkg/projects/project.go
@@ -18,9 +18,15 @@ import (
 //
 // Projects are containers for traces, datasets, prompts, and other Langfuse resources.
 // They can have custom metadata and data retention policies.
+type Organization struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 type Project struct {
 	ID            string         `json:"id,omitempty"`
 	Name          string         `json:"name"`
+	Organization  Organization   `json:"organization"`
 	Metadata      map[string]any `json:"metadata,omitempty"`
 	RetentionDays int            `json:"retentionDays,omitempty"`
 }
@@ -41,7 +47,7 @@ type CreateProjectRequest struct {
 type UpdateProjectRequest struct {
 	Name      string         `json:"name"`
 	Metadata  map[string]any `json:"metadata,omitempty"`
-	Retention int            `json:"retention"`
+	Retention *int           `json:"retention,omitempty"`
 }
 
 // ProjectDeletionResponse represents the response from deleting a project.
@@ -83,7 +89,9 @@ type APIKeyResponse struct {
 
 // CreateAPIKeyRequest represents the request payload for creating an API key.
 type CreateAPIKeyRequest struct {
-	Note string `json:"note,omitempty"`
+	Note      string `json:"note,omitempty"`
+	PublicKey string `json:"publicKey,omitempty"`
+	SecretKey string `json:"secretKey,omitempty"`
 }
 
 // APIKeyDeletionResponse represents the response from deleting an API key.

--- a/pkg/projects/project_test.go
+++ b/pkg/projects/project_test.go
@@ -46,6 +46,7 @@ func TestCreateProjectRequest_validate(t *testing.T) {
 }
 
 func TestUpdateProjectRequest_validate(t *testing.T) {
+	retention60 := 60
 	tests := []struct {
 		name    string
 		req     UpdateProjectRequest
@@ -54,13 +55,13 @@ func TestUpdateProjectRequest_validate(t *testing.T) {
 	}{
 		{
 			"valid request",
-			UpdateProjectRequest{Name: "updated-project", Retention: 60},
+			UpdateProjectRequest{Name: "updated-project", Retention: &retention60},
 			false,
 			"",
 		},
 		{
 			"missing name",
-			UpdateProjectRequest{Retention: 60},
+			UpdateProjectRequest{Retention: &retention60},
 			true,
 			"'name' is required",
 		},
@@ -85,7 +86,11 @@ func TestProjectClient_Get(t *testing.T) {
 			require.Equal(t, "GET", r.Method)
 			projects := ProjectsResponse{
 				Data: []Project{
-					{ID: "project-1", Name: "Test Project 1"},
+					{
+						ID:           "project-1",
+						Name:         "Test Project 1",
+						Organization: Organization{ID: "org-1", Name: "Test Organization"},
+					},
 					{ID: "project-2", Name: "Test Project 2"},
 				},
 			}
@@ -102,6 +107,7 @@ func TestProjectClient_Get(t *testing.T) {
 	require.Len(t, projects.Data, 2)
 	require.Equal(t, "project-1", projects.Data[0].ID)
 	require.Equal(t, "Test Project 1", projects.Data[0].Name)
+	require.Equal(t, "org-1", projects.Data[0].Organization.ID)
 	require.Equal(t, "project-2", projects.Data[1].ID)
 	require.Equal(t, "Test Project 2", projects.Data[1].Name)
 }
@@ -167,14 +173,14 @@ func TestProjectClient_Update(t *testing.T) {
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
 			require.Equal(t, "updated-project", req.Name)
-			require.Equal(t, 60, req.Retention)
+			require.Equal(t, 60, *req.Retention)
 
 			// Return the updated project
 			project := Project{
 				ID:            "test-project-id",
 				Name:          req.Name,
 				Metadata:      req.Metadata,
-				RetentionDays: req.Retention,
+				RetentionDays: *req.Retention,
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -186,10 +192,11 @@ func TestProjectClient_Update(t *testing.T) {
 	cli := resty.New().SetBaseURL(server.URL)
 	client := NewClient(cli)
 
+	retention := 60
 	updateReq := &UpdateProjectRequest{
 		Name:      "updated-project",
 		Metadata:  map[string]any{"updated": "true"},
-		Retention: 60,
+		Retention: &retention,
 	}
 
 	project, err := client.Update(context.Background(), "test-project-id", updateReq)
@@ -202,7 +209,8 @@ func TestProjectClient_Update(t *testing.T) {
 func TestProjectClient_Update_MissingProjectID(t *testing.T) {
 	cli := resty.New()
 	client := NewClient(cli)
-	updateReq := &UpdateProjectRequest{Name: "test", Retention: 30}
+	retention := 30
+	updateReq := &UpdateProjectRequest{Name: "test", Retention: &retention}
 	_, err := client.Update(context.Background(), "", updateReq)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "'projectID' is required")
@@ -308,6 +316,8 @@ func TestProjectClient_CreateApiKey(t *testing.T) {
 			var req CreateAPIKeyRequest
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
+			require.Equal(t, "pk-lf-custom", req.PublicKey)
+			require.Equal(t, "sk-lf-custom", req.SecretKey)
 
 			note := "Test API Key"
 			if req.Note != "" {
@@ -334,7 +344,11 @@ func TestProjectClient_CreateApiKey(t *testing.T) {
 	client := NewClient(cli)
 
 	note := "Test API Key"
-	createReq := &CreateAPIKeyRequest{Note: note}
+	createReq := &CreateAPIKeyRequest{
+		Note:      note,
+		PublicKey: "pk-lf-custom",
+		SecretKey: "sk-lf-custom",
+	}
 
 	apiKey, err := client.CreateAPIKey(context.Background(), "test-project-id", createReq)
 	require.NoError(t, err)

--- a/pkg/prompts/prompt.go
+++ b/pkg/prompts/prompt.go
@@ -236,15 +236,18 @@ func (query *ListParams) ToQueryString() string {
 // GetParams defines the parameters for retrieving a specific prompt.
 //
 // Use Name to specify the prompt name, Label for a specific label,
-// and Version for a specific version. If Version is 0, the latest version is returned.
+// Version for a specific version, and Resolve to control dependency resolution.
+// If Version is 0, the latest version is returned. A nil Resolve uses the API default.
 type GetParams struct {
 	Name    string
 	Label   string
 	Version int
+	Resolve *bool
 }
 
 type PromptMeta struct {
 	Name          string    `json:"name"`
+	Type          string    `json:"type"`
 	Labels        []string  `json:"labels"`
 	Tags          []string  `json:"tags"`
 	Versions      []int     `json:"versions"`
@@ -290,6 +293,9 @@ func (c *Client) Get(ctx context.Context, params GetParams) (*PromptEntry, error
 	}
 	if params.Label != "" {
 		req.SetQueryParam("label", params.Label)
+	}
+	if params.Resolve != nil {
+		req.SetQueryParam("resolve", strconv.FormatBool(*params.Resolve))
 	}
 	req.SetPathParam("name", params.Name)
 

--- a/pkg/prompts/prompt_test.go
+++ b/pkg/prompts/prompt_test.go
@@ -31,9 +31,11 @@ func TestListParams_ToQueryString(t *testing.T) {
 }
 
 func TestPromptClient_Get(t *testing.T) {
+	resolve := false
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			require.Equal(t, "/v2/prompts/test-prompt", r.URL.Path)
+			require.Equal(t, "false", r.URL.Query().Get("resolve"))
 			prompt := PromptEntry{Name: "test-prompt"}
 			w.Header().Set("Content-Type", "application/json")
 			err := json.NewEncoder(w).Encode(prompt)
@@ -43,9 +45,15 @@ func TestPromptClient_Get(t *testing.T) {
 
 	cli := resty.New().SetBaseURL(server.URL)
 	client := NewClient(cli)
-	prompt, err := client.Get(context.Background(), GetParams{Name: "test-prompt"})
+	prompt, err := client.Get(context.Background(), GetParams{Name: "test-prompt", Resolve: &resolve})
 	require.NoError(t, err)
 	require.Equal(t, "test-prompt", prompt.Name)
+}
+
+func TestPromptMetaIncludesType(t *testing.T) {
+	var prompt PromptMeta
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"welcome","type":"chat"}`), &prompt))
+	require.Equal(t, "chat", prompt.Type)
 }
 
 func TestPromptClient_List(t *testing.T) {

--- a/pkg/scores/config.go
+++ b/pkg/scores/config.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/git-hulk/langfuse-go/pkg/common"
 )
@@ -52,15 +54,23 @@ type CreateScoreConfigRequest struct {
 	Description string           `json:"description,omitempty"`
 }
 
+var scoreConfigNamePattern = regexp.MustCompile(`^[A-Za-z0-9_ .()-]+$`)
+
 func (r *CreateScoreConfigRequest) validate() error {
 	if r.Name == "" {
 		return errors.New("'name' is required")
+	}
+	if utf8.RuneCountInString(r.Name) > 35 {
+		return errors.New("'name' must not exceed 35 characters")
+	}
+	if !scoreConfigNamePattern.MatchString(r.Name) {
+		return errors.New("'name' contains unsupported characters")
 	}
 	if r.DataType == "" {
 		return errors.New("'dataType' is required")
 	}
 	// Validate that dataType is a valid value
-	validDataTypes := []ScoreDataType{ScoreDataTypeNumeric, ScoreDataTypeBoolean, ScoreDataTypeCategorical}
+	validDataTypes := []ScoreDataType{ScoreDataTypeNumeric, ScoreDataTypeBoolean, ScoreDataTypeCategorical, ScoreDataTypeText}
 	isValid := false
 	for _, dt := range validDataTypes {
 		if r.DataType == dt {
@@ -69,7 +79,7 @@ func (r *CreateScoreConfigRequest) validate() error {
 		}
 	}
 	if !isValid {
-		return fmt.Errorf("invalid 'dataType': %s, must be one of NUMERIC, BOOLEAN, CATEGORICAL", r.DataType)
+		return fmt.Errorf("invalid 'dataType': %s, must be one of NUMERIC, BOOLEAN, CATEGORICAL, TEXT", r.DataType)
 	}
 
 	// Validate categories for categorical scores

--- a/pkg/scores/config_test.go
+++ b/pkg/scores/config_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -51,6 +52,32 @@ func TestCreateScoreConfigRequest_validate(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "valid text config",
+			request: CreateScoreConfigRequest{
+				Name:     "written feedback",
+				DataType: ScoreDataTypeText,
+			},
+			wantErr: false,
+		},
+		{
+			name: "name exceeds current API limit",
+			request: CreateScoreConfigRequest{
+				Name:     strings.Repeat("a", 36),
+				DataType: ScoreDataTypeText,
+			},
+			wantErr: true,
+			errMsg:  "'name' must not exceed 35 characters",
+		},
+		{
+			name: "name contains unsupported characters",
+			request: CreateScoreConfigRequest{
+				Name:     "quality!",
+				DataType: ScoreDataTypeText,
+			},
+			wantErr: true,
+			errMsg:  "'name' contains unsupported characters",
 		},
 		{
 			name: "missing name",

--- a/pkg/scores/score.go
+++ b/pkg/scores/score.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/git-hulk/langfuse-go/pkg/common"
 	"github.com/git-hulk/langfuse-go/pkg/traces"
@@ -35,14 +36,15 @@ const (
 
 // ScoreDataType represents the data type and format of a score value.
 //
-// Scores can be numeric (float values), boolean (true/false), or categorical
-// (predefined categories with associated values).
+// Scores can be numeric, boolean, categorical, correction, or text values.
 type ScoreDataType string
 
 const (
 	ScoreDataTypeNumeric     ScoreDataType = "NUMERIC"
 	ScoreDataTypeBoolean     ScoreDataType = "BOOLEAN"
 	ScoreDataTypeCategorical ScoreDataType = "CATEGORICAL"
+	ScoreDataTypeCorrection  ScoreDataType = "CORRECTION"
+	ScoreDataTypeText        ScoreDataType = "TEXT"
 )
 
 // Score represents an evaluation score attached to a trace, observation, or session.
@@ -53,6 +55,7 @@ const (
 type Score struct {
 	DataType      ScoreDataType     `json:"dataType"`
 	Value         any               `json:"value"`
+	StringValue   string            `json:"stringValue,omitempty"`
 	ID            string            `json:"id"`
 	TraceID       string            `json:"traceId,omitempty"`
 	SessionID     string            `json:"sessionId,omitempty"`
@@ -68,6 +71,7 @@ type Score struct {
 	AuthorUserID  string            `json:"authorUserId,omitempty"`
 	QueueID       string            `json:"queueId,omitempty"`
 	Metadata      any               `json:"metadata,omitempty"`
+	Environment   string            `json:"environment"`
 	Trace         traces.TraceEntry `json:"trace,omitempty"`
 }
 
@@ -89,6 +93,8 @@ type CreateScoreRequest struct {
 	ConfigID      string        `json:"configId,omitempty"`
 	Environment   string        `json:"environment,omitempty"`
 	Metadata      any           `json:"metadata,omitempty"`
+	QueueID       string        `json:"queueId,omitempty"`
+	Source        ScoreSource   `json:"source,omitempty"`
 }
 
 func (r *CreateScoreRequest) validate() error {
@@ -98,9 +104,14 @@ func (r *CreateScoreRequest) validate() error {
 	if r.Value == nil {
 		return errors.New("'value' is required")
 	}
-	// At least one of TraceID, SessionID, or DatasetRunID must be provided
-	if r.TraceID == "" && r.SessionID == "" && r.DatasetRunID == "" {
-		return errors.New("at least one of 'traceId', 'sessionId', or 'datasetRunID' is required")
+	if r.TraceID == "" && r.SessionID == "" && r.ObservationID == "" && r.DatasetRunID == "" {
+		return errors.New("at least one of 'traceId', 'sessionId', 'observationId', or 'datasetRunId' is required")
+	}
+	if r.Source != "" && r.Source != ScoreSourceAPI && r.Source != ScoreSourceAnnotation {
+		return errors.New("'source' must be API or ANNOTATION")
+	}
+	if r.Source == ScoreSourceAnnotation && r.ConfigID == "" && r.DataType != ScoreDataTypeCorrection {
+		return errors.New("'configId' is required for ANNOTATION scores unless dataType is CORRECTION")
 	}
 	// Validate value according to data type
 	if err := r.validateValueByDataType(); err != nil {
@@ -122,21 +133,27 @@ type CreateScoreResponse struct {
 // to filter by creation time. Source and DataType can filter by score characteristics.
 // Page and Limit control pagination.
 type ListParams struct {
-	Page          int
-	Limit         int
-	UserID        string
-	Name          string
-	FromTimestamp time.Time
-	ToTimestamp   time.Time
-	Environment   []string
-	Source        ScoreSource
-	Operator      string
-	Value         float64
-	ScoreIDs      []string
-	ConfigID      string
-	QueueID       string
-	DataType      ScoreDataType
-	TraceTags     []string
+	Page           int
+	Limit          int
+	UserID         string
+	Name           string
+	FromTimestamp  time.Time
+	ToTimestamp    time.Time
+	Environment    []string
+	Source         ScoreSource
+	Operator       string
+	Value          float64
+	ScoreIDs       []string
+	ConfigID       string
+	QueueID        string
+	DataType       ScoreDataType
+	TraceTags      []string
+	TraceID        string
+	SessionID      string
+	ObservationIDs []string
+	DatasetRunID   string
+	Fields         []string
+	Filter         string
 }
 
 // ToQueryString converts the ListParams to a URL query string.
@@ -195,6 +212,24 @@ func (p *ListParams) ToQueryString() string {
 				parts = append(parts, "traceTags="+url.QueryEscape(tag))
 			}
 		}
+	}
+	if p.TraceID != "" {
+		parts = append(parts, "traceId="+url.QueryEscape(p.TraceID))
+	}
+	if p.SessionID != "" {
+		parts = append(parts, "sessionId="+url.QueryEscape(p.SessionID))
+	}
+	if len(p.ObservationIDs) > 0 {
+		parts = append(parts, "observationId="+url.QueryEscape(strings.Join(p.ObservationIDs, ",")))
+	}
+	if p.DatasetRunID != "" {
+		parts = append(parts, "datasetRunId="+url.QueryEscape(p.DatasetRunID))
+	}
+	if len(p.Fields) > 0 {
+		parts = append(parts, "fields="+url.QueryEscape(strings.Join(p.Fields, ",")))
+	}
+	if p.Filter != "" {
+		parts = append(parts, "filter="+url.QueryEscape(p.Filter))
 	}
 
 	return strings.Join(parts, "&")
@@ -306,9 +341,18 @@ func (r *CreateScoreRequest) validateValueByDataType() error {
 		default:
 			return errors.New("value must be 0, 1, or boolean for BOOLEAN data type")
 		}
-	case ScoreDataTypeCategorical:
+	case ScoreDataTypeCategorical, ScoreDataTypeCorrection:
 		if _, ok := r.Value.(string); !ok {
-			return errors.New("value must be a string for CATEGORICAL data type")
+			return fmt.Errorf("value must be a string for %s data type", r.DataType)
+		}
+	case ScoreDataTypeText:
+		value, ok := r.Value.(string)
+		if !ok {
+			return errors.New("value must be a string for TEXT data type")
+		}
+		length := utf8.RuneCountInString(value)
+		if length < 1 || length > 500 {
+			return errors.New("value must be between 1 and 500 characters for TEXT data type")
 		}
 	case ScoreDataTypeNumeric:
 		switch r.Value.(type) {

--- a/pkg/scores/score_test.go
+++ b/pkg/scores/score_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,7 +45,6 @@ func TestCreateScoreRequest_validate(t *testing.T) {
 			request: CreateScoreRequest{
 				Name:          "relevance",
 				Value:         1.0,
-				TraceID:       "trace-123",
 				ObservationID: "obs-789",
 			},
 			wantErr: false,
@@ -74,7 +74,62 @@ func TestCreateScoreRequest_validate(t *testing.T) {
 				Value: 0.8,
 			},
 			wantErr: true,
-			errMsg:  "at least one of 'traceId', 'sessionId', or 'datasetRunID' is required",
+			errMsg:  "at least one of 'traceId', 'sessionId', 'observationId', or 'datasetRunId' is required",
+		},
+		{
+			name: "valid text score",
+			request: CreateScoreRequest{
+				Name:     "feedback",
+				Value:    "clear and helpful",
+				TraceID:  "trace-123",
+				DataType: ScoreDataTypeText,
+			},
+			wantErr: false,
+		},
+		{
+			name: "text score exceeds current API limit",
+			request: CreateScoreRequest{
+				Name:     "feedback",
+				Value:    strings.Repeat("a", 501),
+				TraceID:  "trace-123",
+				DataType: ScoreDataTypeText,
+			},
+			wantErr: true,
+			errMsg:  "between 1 and 500 characters",
+		},
+		{
+			name: "valid correction score",
+			request: CreateScoreRequest{
+				Name:     "correction",
+				Value:    "corrected output",
+				TraceID:  "trace-123",
+				DataType: ScoreDataTypeCorrection,
+				Source:   ScoreSourceAnnotation,
+			},
+			wantErr: false,
+		},
+		{
+			name: "eval source is rejected by create endpoint",
+			request: CreateScoreRequest{
+				Name:    "accuracy",
+				Value:   0.9,
+				TraceID: "trace-123",
+				Source:  ScoreSourceEval,
+			},
+			wantErr: true,
+			errMsg:  "'source' must be API or ANNOTATION",
+		},
+		{
+			name: "annotation source requires config",
+			request: CreateScoreRequest{
+				Name:     "feedback",
+				Value:    "draft",
+				TraceID:  "trace-123",
+				DataType: ScoreDataTypeText,
+				Source:   ScoreSourceAnnotation,
+			},
+			wantErr: true,
+			errMsg:  "'configId' is required for ANNOTATION scores",
 		},
 	}
 
@@ -167,6 +222,18 @@ func TestListParams_ToQueryString(t *testing.T) {
 				TraceTags: []string{"experiment", "production"},
 			},
 			want: "traceTags=experiment&traceTags=production",
+		},
+		{
+			name: "with new v2 filters",
+			params: ListParams{
+				TraceID:        "trace-123",
+				SessionID:      "session-123",
+				ObservationIDs: []string{"obs-1", "obs-2"},
+				DatasetRunID:   "run-123",
+				Fields:         []string{"score", "trace"},
+				Filter:         `[{"type":"string","column":"name","operator":"=","value":"quality"}]`,
+			},
+			want: "traceId=trace-123&sessionId=session-123&observationId=obs-1%2Cobs-2&datasetRunId=run-123&fields=score%2Ctrace&filter=%5B%7B%22type%22%3A%22string%22%2C%22column%22%3A%22name%22%2C%22operator%22%3A%22%3D%22%2C%22value%22%3A%22quality%22%7D%5D",
 		},
 		{
 			name: "all parameters",


### PR DESCRIPTION
## Summary
- align existing annotation, comment, dataset, media, model, project, prompt, score, metrics, and LLM connection contracts with the updated `openapi.yml`
- add newly exposed fields, enum values, query parameters, and request validation to existing SDK methods
- keep newly introduced upstream endpoints out of scope

## Validation
- `make test`
- `go test ./...`
- `go build ./...`
- `git diff --check`

Note: the first race-suite run hit the repository's timing-sensitive `TestProcessor_BufferFull`; an immediate full rerun passed.